### PR TITLE
Sysctl IP forwarding

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,10 +32,6 @@ repos:
     rev: v0.39.0
     hooks:
       - id: markdownlint-fix-docker
-  - repo: https://github.com/aquasecurity/tfsec
-    rev: v1.28.5
-    hooks:
-      - id: tfsec-docker
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.32.0
     hooks:

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -12,8 +12,8 @@
   roles:
     - geerlingguy.swap
   vars:
-    swap_file_size_mb: "{{ SWAP_FILE_SIZE_MB }}"
-    swap_swappiness: "{{ SWAP_SWAPPINESS }}"
+    swap_file_size_mb: "{{ inv_swap_file_size_mb }}"
+    swap_swappiness: "{{ inv_swap_swappiness }}"
 
 - name: Install and update apt
   hosts: ionos_vpngate_2
@@ -42,7 +42,7 @@
       - git # for certbot install (git actually did not work, it seems)
       - cron # for certbot reload
 
-- name: Install Tailscale on the server
+- name: Install Tailscale on the server and make this node an exit node
   hosts: ionos_vpngate_2
   become: true
   gather_facts: true
@@ -50,7 +50,49 @@
     - artis3n.tailscale
   vars:
     tailscale_authkey: "{{ TAILSCALE_AUTHKEY }}"
-    tailscale_args: "--advertise-exit-node --hostname={{ inv_adguard_fqdn }} --ssh"
+    tailscale_args: --advertise-exit-node --hostname={{ inv_adguard_fqdn }} --ssh
+  pre_tasks:
+    - name: Set sysctl values to enable packet forwarding and according security policies
+      ansible.posix.sysctl:
+        name: "{{ item.sysctl_key }}"
+        value: "{{ item.sysctl_value }}"
+        sysctl_file: /etc/sysctl.d/99-tailscale.conf
+        sysctl_set: true
+        state: present
+      loop:
+        - description: Reverse Path Filter v4 (Spoof protection)
+          sysctl_key: net.ipv4.conf.all.rp_filter
+          sysctl_value: "1"
+        - description: TCP Syncookies v4
+          sysctl_key: net.ipv4.tcp_syncookies
+          sysctl_value: "1"
+        - description: IPv4 Packet Forwarding
+          sysctl_key: net.ipv4.ip_forward
+          sysctl_value: "1"
+        - description: IPv6 Packet Forwarding
+          sysctl_key: net.ipv6.conf.all.forwarding
+          sysctl_value: "1"
+        - description: Do not accept ICMP v4 redirects (MITM prevention)
+          sysctl_key: net.ipv4.conf.all.accept_redirects
+          sysctl_value: "0"
+        - description: Do not accept ICMP v6 redirects (MITM prevention)
+          sysctl_key: net.ipv6.conf.all.accept_redirects
+          sysctl_value: "0"
+        - description: Allow secure ICMP v4 redirects
+          sysctl_key: net.ipv4.conf.all.secure_redirects
+          sysctl_value: "1"
+        - description: Do not send ICMP v4 redirects
+          sysctl_key: net.ipv4.conf.all.send_redirects
+          sysctl_value: "0"
+        - description: Do not accept IPv4 source route packets
+          sysctl_key: net.ipv4.conf.all.accept_source_route
+          sysctl_value: "0"
+        - description: Do not accept IPv6 source route packets
+          sysctl_key: net.ipv6.conf.all.accept_source_route
+          sysctl_value: "0"
+        - description: Log Martian Packets
+          sysctl_key: net.ipv4.conf.all.log_martians
+          sysctl_value: "1"
 
 - name: Install DNSCrypt Proxy
   hosts: ionos_vpngate_2
@@ -349,7 +391,7 @@
           url: https://pgl.yoyo.org/adservers/serverlist.php?hostformat=adblock&mimetype=plaintext
       tls:
         enabled: true
-        #server_name: "{{ inv_adguard_fqdn }}"
+        # server_name: "{{ inv_adguard_fqdn }}"
         port_https: 443
         port_dns_over_tls: 853
         port_dns_over_quic: 853


### PR DESCRIPTION
Enabled sysctl IP forwarding, which is necessary to provide a tailscale exit node. Solves #6 